### PR TITLE
chore: Update z-index values for overlay and close button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -250,7 +250,7 @@ header.desktop-head h1 a:hover {
     left: 0;
     width: 100%;
     height: 100%;
-    z-index: 98;
+    z-index: 999;
     background-color: rgba(0, 0, 0, 0.8); /* semi-transparent black background */
     cursor: pointer;
     transition: background-color 300ms ease;
@@ -291,7 +291,7 @@ header.desktop-head h1 a:hover {
 }
   
 .close {
-    z-index: 999;
+    z-index: 1000;
     position: absolute;
     top: 20px;
     right: 20px;


### PR DESCRIPTION
![4372126edac38a180dbbbc3acbeab6cd](https://github.com/user-attachments/assets/37f78cca-6c0d-4df1-bbb8-6eb222f4ae62)

An issue where the 'x' button was unclickable: the top bar is above the fullscreen overlay.

↓Effect after adjustment.
![c654b3997fae001522c60a75f552241b](https://github.com/user-attachments/assets/47fa8daf-149b-40c7-8f00-1cdbe0c3de1e)
Adjusted the corresponding values accordingly. Now it should be close > fullscreen > top bar.
**Code review required.**